### PR TITLE
[PLAT-674] Ensure that image exists before deploying

### DIFF
--- a/.github/workflows/get-image.yml
+++ b/.github/workflows/get-image.yml
@@ -42,5 +42,13 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ECR_REPOSITORY }}
           TAG: ${{ inputs.TAG }}
+          DOCKER_CLI_EXPERIMENTAL: enabled
+        shell: bash
         run: |
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$TAG"
+          NEW_IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$TAG
+          if docker manifest inspect $NEW_IMAGE >/dev/null; then
+            echo "::set-output name=image::$NEW_IMAGE"
+          else
+            echo "Image does not exists in ECR"
+            exit 1
+          fi


### PR DESCRIPTION
This change will ensure the image exists before returning the image to be deployed.