### PR TITLE
Adds check for preview and refresh in Pulumi command

### DIFF
--- a/.github/workflows/pulumi-command-venv.yaml
+++ b/.github/workflows/pulumi-command-venv.yaml
@@ -46,6 +46,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+    
+      - name: Check for refresh and preview
+        if: inputs.refresh == 'true'
+        id: refresh-preview-check
+        run: | 
+          if [[ ${{ inputs.command }} == *"preview"* ]]; then
+            echo "Cannot have refresh==true with a preview command!"
+            exit 1
+          fi
 
       - name: Get changes
         id: changes

--- a/.github/workflows/pulumi-command-venv.yaml
+++ b/.github/workflows/pulumi-command-venv.yaml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
     
       - name: Check for refresh and preview
-        if: inputs.refresh == 'true'
+        if: inputs.refresh
         id: refresh-preview-check
         run: | 
           if [[ ${{ inputs.command }} == *"preview"* ]]; then

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Shared Github Actions
+
+## Usage: Workflows 
+
+### Pulumi Command Venv
+
+Note: Refresh and preview cannot be used in the same command.


### PR DESCRIPTION
If refresh == true and a pulumi command is run, pulumi will throw permissions errors. This adds a check to nicely inform this error. 