### PR TITLE
Github output, syntax for multiline string

### DIFF
--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -23,7 +23,10 @@ runs:
       id: 'deploy-message'
       shell: bash
       run: |
-        echo "commit_msg=$(git log -1 --format=%B)" >> $GITHUB_OUTPUT
+        echo "commit_msg<<EOF" >> $GITHUB_OUTPUT
+        echo "$(git log -1 --format=%B)" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:


### PR DESCRIPTION
In my previous change, I did not notice that this formatter for the most recent commit was outputting a multiline string, which will not work with the single line assignment.

Modify to use correct multi-line syntax as per: https://stackoverflow.com/questions/74137120/how-to-fix-or-avoid-error-unable-to-process-file-command-output-successfully
