### PR TITLE
TRE-2755: add more context to slack notifications

### DIFF
--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -3,24 +3,24 @@ description: "Publishes formatted message to Slack"
 
 inputs:
   SERVICE:
-    description: 'Name of the service deployed'
+    description: "Name of the service deployed"
     required: true
   ENVIRONMENT:
-    description: 'Environment being deployed too'
+    description: "Environment being deployed too"
     required: true
   SLACK_WEBHOOK:
-    description: 'Slack Webhook'
+    description: "Slack Webhook"
     required: true
   COLOR:
-    description: 'Color of slack boarder'
+    description: "Color of slack boarder"
     required: false
-    default: '#00FF00'
+    default: "#00FF00"
 
 runs:
   using: "composite"
   steps:
-    - name: 'Get message'
-      id: 'deploy-message'
+    - name: "Get message"
+      id: "deploy-message"
       shell: bash
       run: |
         echo "commit_msg<<EOF" >> $GITHUB_OUTPUT
@@ -31,8 +31,9 @@ runs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_USERNAME: ${{ inputs.SERVICE }} ${{ inputs.ENVIRONMENT }}
+        SLACK_TITLE: ${{ inputs.SERVICE }} ${{ inputs.ENVIRONMENT }}
         SLACK_MESSAGE: ${{ steps.deploy-message.outputs.commit_msg }}
         SLACK_COLOR: ${{ inputs.COLOR }}
         SLACK_WEBHOOK: ${{ inputs.SLACK_WEBHOOK }}
-        SLACK_FOOTER: ''
-        SLACK_ICON_EMOJI: ':rocket:'
+        SLACK_FOOTER: ""
+        SLACK_ICON_EMOJI: ":rocket:"


### PR DESCRIPTION
Replaces the default `Message` `SLACK_TITLE`  with `${{ inputs.SERVICE }} ${{ inputs.ENVIRONMENT }}`

![image](https://user-images.githubusercontent.com/2760666/215719888-4129d29f-626b-492c-9a89-ba9cb4018085.png)
