### PR TITLE
Remove invalid keys from taskdef before using it

### DIFF
--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -37,6 +37,15 @@ jobs:
         run: |
           TASK_DEFINITION="$CLUSTER_NAME-$APP_NAME-task"
           aws ecs describe-task-definition --task-definition $TASK_DEFINITION --query taskDefinition > $APP_NAME-task-definition.json
+          echo $(cat $APP_NAME-task-definition.json | jq 'del(
+                  .taskDefinitionArn,
+                  .requiresAttributes,
+                  .compatibilities,
+                  .revision,
+                  .status,
+                  .registeredAt,
+                  .registeredBy
+              )') > $APP_NAME-task-definition.json
 
       - name: Update task definition
         id: update-task


### PR DESCRIPTION
See: https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/176

There are way too many warnings every time this shared action runs, means we're more likely to miss real problems surfacing.

Quiet it down.