### PR TITLE
Revert "Revert "SRE-2115: pass additional env vars to deploy (#13)"

### DIFF
--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -15,6 +15,9 @@ on:
       REGION:
         required: true
         type: string
+      ADDITIONAL_ENVIRONMENT_VARS:
+        required: false
+        type: string
     secrets:
       ROLE_TO_ASSUME:
         required: true
@@ -54,6 +57,7 @@ jobs:
           task-definition: ${{ inputs.APP_NAME }}-task-definition.json
           container-name: ${{ inputs.APP_NAME }}
           image: ${{ inputs.IMAGE }}
+          environment-variables: ${{ inputs.ADDITIONAL_ENVIRONMENT_VARS }}
 
       - name: Deploy to cluster
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1


### PR DESCRIPTION
Confirmed this does not replace existing container env vars: https://github.com/aws-actions/amazon-ecs-render-task-definition/blob/1414c0acaeaa4634a48f96aaba0baf6088f6aca6/index.js#L66

This will only append or replace those env vars specified