### PR TITLE
[PRV-2305] update actions to use latest versions

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.ROLE_TO_ASSUME }}
         aws-region: us-west-2

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -26,9 +26,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.REGION }}

--- a/.github/workflows/get-image.yml
+++ b/.github/workflows/get-image.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS prod credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
           aws-region: us-west-2
@@ -34,7 +34,7 @@ jobs:
 
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Get image
         id: get-image

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -27,9 +27,9 @@ jobs:
       image: ${{ steps.publish-image.outputs.image }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure AWS staging credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.STAGING_ROLE_TO_ASSUME }}
           aws-region: us-west-2
@@ -37,7 +37,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-staging-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Pull image
         id: pull-image
@@ -51,7 +51,7 @@ jobs:
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$TAG" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PROD_ROLE_TO_ASSUME }}
           aws-region: us-west-2
@@ -59,7 +59,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-prod-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Publish image
         id: publish-image

--- a/.github/workflows/pulumi-command-venv.yml
+++ b/.github/workflows/pulumi-command-venv.yml
@@ -43,14 +43,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-    
+
       - name: Check for refresh and preview
         if: inputs.refresh
         id: refresh-preview-check
-        run: | 
+        run: |
           if [[ ${{ inputs.command }} == *"preview"* ]]; then
             echo "Cannot have refresh==true with a preview command!"
             exit 1
@@ -64,13 +64,13 @@ jobs:
           else
             path=HEAD^..HEAD
           fi
-          
+
           if git diff --name-only $path | xargs dirname | grep -q ^${{ inputs.dir }}; then
             changed=true
           else
             changed=false
           fi
-          
+
           echo "dir-changed=$changed" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-python@v4
@@ -100,7 +100,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: steps.changes.outputs.dir-changed == 'true'
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.role-to-assume }}


### PR DESCRIPTION
## Ticket

https://lithichq.atlassian.net/browse/PRV-2305

## Description

The shared github actions are older versions that leverage a now deprecated version of Nodejs. This update uses the latest version of the actions that reference the correct version of node. 

What can I do to test these to make sure they don't break any existing flows?